### PR TITLE
Feature/fix-suppressed-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Options:
 
   # Behavior Options
   -f, --force                     Overwrite existing files without prompting (default: false)
+  -q, --quiet                     Suppress console output (default: false)
 
   # Information Options
   -v, --version                   Display the version number
@@ -108,6 +109,9 @@ Examples:
   # Force overwrite without prompting
   repo-serialize -f
 
+  # Run quietly (suppress console output)
+  repo-serialize -q
+
   # Complete example with all option types
   repo-serialize --dir ./project \
                  --output ./analysis \
@@ -117,7 +121,8 @@ Examples:
                  --all \
                  --no-gitignore \
                  --ignore "*.log" "temp/" \
-                 --force
+                 --force \
+                 --quiet
 
   # LLM-optimized snapshot (using 4MB limit)
   repo-serialize -m 4MB -a -o ./llm-analysis
@@ -142,6 +147,7 @@ const options = {
     ignoreDefaultPatterns: false,     // Set to true to disable default ignore patterns
     noGitignore: false,              // Set to true to disable .gitignore processing
     force: false,                    // Set to true to overwrite existing files
+    silent: false,                   // Set to true to suppress console output
 
     // Optional callbacks
     onProgress: (processedFiles, totalFiles) => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -69,6 +69,7 @@ program
 
     // Behavior Options
     .option('-f, --force', 'Overwrite existing files without prompting (default: false)')
+    .option('-q, --quiet', 'Reduce output to console (default: false)')
 
     // Information Options
     .version(version, '-v, --version', 'Display the version number')
@@ -86,7 +87,8 @@ program
                 isCliCall: true,
                 maxFileSize: parseFileSize(options.maxFileSize),
                 ignoreDefaultPatterns: options.all,
-                noGitignore: !options.gitignore  // Commander sets gitignore=false when --no-gitignore is used
+                noGitignore: !options.gitignore,  // Commander sets gitignore=false when --no-gitignore is used
+                silent: options.quiet
             };
 
             try {


### PR DESCRIPTION
This pull request introduces a new `silent` option to suppress console output and includes updates to the `README.md` file and test cases to support this change. The most important changes are outlined below:

### New Feature: Silent Option

* Added a `silent` option to the command-line interface and internal options to suppress console output. (`README.md`, `src/index.js`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R93) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R305) [[3]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L317-R319)
* Updated the `generateContentFile` function to accept the `silent` parameter and suppress console logs when specified. (`src/index.js`) [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R242-R245) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L276-R274) [[3]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R284-R285) [[4]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L364-R366)

### Documentation Updates

* Added descriptions for the new `-q, --quiet` option in the `README.md` file under Behavior Options and Examples sections. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R93) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R112-R114) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R125)
* Updated the example commands in the `README.md` to include the `--quiet` option. (`README.md`)

### Testing Enhancements

* Added a new test case to verify the behavior of the `silent` option, ensuring non-text file messages are correctly suppressed or logged based on the `silent` flag. (`tests/index.test.js`)
* Refactored existing test cases to accommodate the new `silent` option and ensure consistent test environment setup. (`tests/index.test.js`)