### PR TITLE
Enhance CLI options and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ Options:
 
   # Behavior Options
   -f, --force                     Overwrite existing files without prompting (default: false)
-  -q, --quiet                     Suppress console output (default: false)
+  --silent                        Suppress all console output (default: false)
+  --verbose                       Enable verbose logging of all processed and ignored files (default: false)
+                                 Note: Cannot be used with --silent
 
   # Information Options
-  -v, --version                   Display the version number
+  -V, --version                   Display the version number
   -h, --help                      Display help information
 
 Examples:
@@ -134,39 +136,34 @@ Examples:
 ```javascript
 const { serializeRepo } = require('repo-serializer');
 
-// All options shown with default values
-const options = {
-    // Required options
+// Basic usage with default options
+await serializeRepo({
     repoRoot: '/path/to/repo',
-    outputDir: '/path/to/output',
+    outputDir: '/path/to/output'
+});
 
-    // Optional configurations
-    structureFile: 'repo_structure.txt',
-    contentFile: 'repo_content.txt',
-    additionalIgnorePatterns: ['*.log', 'temp/'],
-    maxFileSize: 8192,                // 8KB, must be between 512B and 4MB
-    ignoreDefaultPatterns: false,     // Set to true to disable default ignore patterns
-    noGitignore: false,              // Set to true to disable .gitignore processing
-    force: false,                    // Set to true to overwrite existing files
-    silent: false,                   // Set to true to suppress console output
+// Advanced usage with all options
+await serializeRepo({
+    // Input/Output options
+    repoRoot: '/path/to/repo',           // Directory to serialize
+    outputDir: '/path/to/output',        // Output directory
+    structureFile: 'structure.txt',      // Custom structure filename
+    contentFile: 'content.txt',          // Custom content filename
 
-    // Optional callbacks
-    onProgress: (processedFiles, totalFiles) => {
-        console.log(`Processed ${processedFiles}/${totalFiles} files`);
-    },
-    onFileProcessed: (filePath, success) => {
-        console.log(`Processed: ${filePath}`);
-    }
-};
+    // Processing options
+    maxFileSize: 8192,                   // Max file size in bytes (512B-4MB)
+    ignoreDefaultPatterns: false,        // Set to true to disable default ignores
+    noGitignore: false,                  // Set to true to disable .gitignore processing
+    additionalIgnorePatterns: ['*.log'], // Additional patterns to ignore
 
-// Async usage
-await serializeRepo(options);
-
-// Promise usage
-serializeRepo(options)
-    .then(() => console.log('Serialization complete'))
-    .catch(error => console.error('Error:', error));
+    // Behavior options
+    force: false,                        // Overwrite without prompting
+    silent: false,                       // Suppress all console output
+    verbose: false                       // Enable verbose logging (cannot be used with silent)
+});
 ```
+
+The function returns a Promise that resolves when the serialization is complete.
 
 ## Output Format
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { program } = require('commander');
+const { program, Option } = require('commander');
 const path = require('path');
 const fs = require('fs');
 const readline = require('readline');
@@ -40,6 +40,7 @@ async function handleExistingFiles(outputDir, structureFile, contentFile) {
             console.log('Operation cancelled.');
             process.exit(0);
         }
+        console.log('');
     }
 }
 
@@ -69,7 +70,8 @@ program
 
     // Behavior Options
     .option('-f, --force', 'Overwrite existing files without prompting (default: false)')
-    .option('-q, --quiet', 'Reduce output to console (default: false)')
+    .addOption(new Option('--silent', 'Suppress all console output (default: false)').conflicts('verbose'))
+    .addOption(new Option('--verbose', 'Enable verbose logging of all processed and ignored files (default: false)').conflicts('silent'))
 
     // Information Options
     .version(version, '-v, --version', 'Display the version number')
@@ -88,7 +90,8 @@ program
                 maxFileSize: parseFileSize(options.maxFileSize),
                 ignoreDefaultPatterns: options.all,
                 noGitignore: !options.gitignore,  // Commander sets gitignore=false when --no-gitignore is used
-                silent: options.quiet
+                silent: options.silent,
+                verbose: options.verbose
             };
 
             try {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -321,6 +321,17 @@ describe('repo-serializer', () => {
          * - Output file management
          */
 
+        test('throws error when verbose and silent are used together', () => {
+            expect(() => {
+                serializeRepo({
+                    repoRoot: tmpDir.name,
+                    outputDir: outputDir.name,
+                    verbose: true,
+                    silent: true
+                });
+            }).toThrow('Cannot use verbose and silent options together');
+        });
+
         test('succeeds when no files exist', () => {
             const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-serializer-'));
             const repoDir = path.join(tmpDir, 'test-repo');
@@ -902,7 +913,29 @@ describe('repo-serializer', () => {
         });
     });
 
-    // File size handling
+    describe('verbose logging', () => {
+        test('logs detailed information when verbose is enabled', async () => {
+            // Create a spy for console.log
+            const consoleSpy = jest.spyOn(console, 'log');
+
+            serializeRepo({
+                repoRoot: tmpDir.name,
+                outputDir: outputDir.name,
+                verbose: true,
+                additionalIgnorePatterns: ['*.tmp', 'temp/']
+            });
+
+            // Verify verbose logging calls
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Added default ignore patterns'));
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Added additional ignore patterns'));
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Added gitignore patterns from'));
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring: ignored.txt'));
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Ignoring: test.log'));
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Adding file: file1.txt'));
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Adding file: src/file2.js'));
+        });
+    });
+
     describe('file size handling', () => {
         /**
          * Tests file size related functionality:


### PR DESCRIPTION
- Updated the CLI to replace the `--quiet` option with `--silent` and added a new `--verbose` option for detailed logging.
- Revised the README.md to reflect these changes, including updated examples and descriptions for the new options.
- Added validation to ensure that `--silent` and `--verbose` cannot be used together.
- Enhanced the `serializeRepo` function and related methods to support verbose logging, improving user feedback during execution.
- Added tests to verify the new logging functionality and the conflict between `--silent` and `--verbose` options.